### PR TITLE
remove the __future__

### DIFF
--- a/docs/tephi/source/sphinxext/custom_class_autodoc.py
+++ b/docs/tephi/source/sphinxext/custom_class_autodoc.py
@@ -14,10 +14,6 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
-
-from __future__ import (absolute_import, division, print_function)
-from six.moves import (filter, input, map, range, zip)  # noqa
-
 from sphinx.ext import autodoc
 from sphinx.ext.autodoc import *
 from sphinx.util import force_decode

--- a/lib/tephi/__init__.py
+++ b/lib/tephi/__init__.py
@@ -22,8 +22,6 @@ barb data.
     This is a beta release module and is liable to change.
 
 """
-from __future__ import absolute_import, division, print_function
-
 from collections import namedtuple
 from collections.abc import Iterable
 from functools import partial

--- a/lib/tephi/_constants.py
+++ b/lib/tephi/_constants.py
@@ -18,7 +18,6 @@
 Tephigram transform and isopleth constants.
 
 """
-from __future__ import absolute_import, division, print_function
 
 # TODO: Discover the meaning of the magic constant numbers.
 

--- a/lib/tephi/isopleths.py
+++ b/lib/tephi/isopleths.py
@@ -19,13 +19,11 @@ Tephigram isopleth support for generating and plotting tephigram lines,
 environment profiles and barbs.
 
 """
-from __future__ import absolute_import, division, print_function
-
 import math
 from matplotlib.collections import PathCollection
+from matplotlib.path import Path
 import matplotlib.pyplot as plt
 import matplotlib.transforms as mtransforms
-from matplotlib.path import Path
 import numpy as np
 from scipy.interpolate import interp1d
 

--- a/lib/tephi/tests/__init__.py
+++ b/lib/tephi/tests/__init__.py
@@ -27,8 +27,6 @@ switched to "tkagg" to allow the interactive visual inspection of
 graphical test results.
 
 """
-from __future__ import absolute_import, division, print_function
-
 import codecs
 import collections
 import io

--- a/lib/tephi/tests/test_tephigram.py
+++ b/lib/tephi/tests/test_tephigram.py
@@ -18,8 +18,6 @@
 Tests the tephigram plotting capability provided by tephi.
 
 """
-from __future__ import absolute_import, division, print_function
-
 import unittest
 
 # Import tephi test package first so that some things can be initialised

--- a/lib/tephi/transforms.py
+++ b/lib/tephi/transforms.py
@@ -18,8 +18,6 @@
 Tephigram transform support.
 
 """
-from __future__ import absolute_import, division, print_function
-
 from matplotlib.transforms import Transform
 import numpy as np
 


### PR DESCRIPTION
This PR is simple code hygiene to purge the use of `__future__` ... it has already arrived, thanks to Python3 :tada:  

@trexfeathers 