### PR TITLE
test imagerepo

### DIFF
--- a/lib/tephi/tests/__init__.py
+++ b/lib/tephi/tests/__init__.py
@@ -38,8 +38,10 @@ import unittest
 import filelock
 import matplotlib
 import numpy as np
+import requests
 
 from tephi import DATA_DIR
+
 
 #: Basepath for test data.
 _DATA_PATH = DATA_DIR
@@ -55,6 +57,22 @@ _HAMMING_DISTANCE = 2
 
 # Whether to display matplotlib output to the screen.
 _DISPLAY_FIGURES = False
+
+
+try:
+    # Added a timeout to stop the call to requests.get hanging when running
+    # on a platform which has restricted/no internet access.
+    requests.get("https://github.com/SciTools/tephi", timeout=5.0)
+    INET_AVAILABLE = True
+except requests.exceptions.ConnectionError:
+    INET_AVAILABLE = False
+
+
+skip_inet = unittest.skipIf(
+    not INET_AVAILABLE,
+    ('Test(s) require an "internet connection", which is not available.'),
+)
+
 
 if '-d' in sys.argv:
     sys.argv.remove('-d')

--- a/lib/tephi/tests/test_imagerepo.py
+++ b/lib/tephi/tests/test_imagerepo.py
@@ -1,0 +1,62 @@
+# Copyright Tephi contributors
+#
+# This file is part of Tephi and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+
+# Import tephi tests first so that some things can be initialised before
+# importing anything else
+import tephi.tests as tests
+
+import codecs
+import itertools
+import json
+import os
+import unittest
+
+import requests
+
+
+BASE_URL = "https://scitools.github.io/test-tephi-imagehash/images"
+IMAGE_MANIFEST = ("https://raw.githubusercontent.com/SciTools/"
+                  "test-tephi-imagehash/gh-pages/image_manifest.txt")
+
+
+@tests.skip_inet
+class TestImageRepoJSON(tests.TephiTest):
+    def test(self):
+        response = requests.get(IMAGE_MANIFEST)
+
+        emsg = 'Failed to download "image_manifest.txt"'
+        self.assertEqual(response.status_code, requests.codes.ok, msg=emsg)
+
+        image_manifest = response.content.decode("utf-8")
+        image_manifest = [line.strip() for line in image_manifest.split("\n")]
+        image_manifest_uris = set(
+            os.path.join(BASE_URL, fname) for fname in image_manifest
+        )
+
+        imagerepo_fname = os.path.join(
+            os.path.dirname(__file__), "results", "imagerepo.json"
+        )
+        with open(imagerepo_fname, "rb") as fi:
+            imagerepo = json.load(codecs.getreader("utf-8")(fi))
+
+        # "imagerepo" maps key: list-of-uris. Put all the uris in one big set.
+        tests_uris = set(itertools.chain.from_iterable(imagerepo.values()))
+
+        missing = list(tests_uris - image_manifest_uris)
+        count = len(missing)
+        if count:
+            emsg = (
+                '"imagerepo.json" references {} image URIs that are not '
+                'listed in "{}":\n\t'
+            )
+            emsg = emsg.format(count, IMAGE_MANIFEST)
+            emsg += "\t".join(uri for uri in missing)
+            # Always fails when we get here: report the problem.
+            self.assertEqual(count, 0, msg=emsg)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds test coverage to ensure the the `imagerepo.json` file contains URIs to images that are already available from `test-tephi-imagehash`.

@trexfeathers 