### PR TITLE
fix logo url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-  <a href="https://scitools.org.uk/iris/docs/latest/" style="display: block; margin: 0 auto;">
+  <a href="https://tephi.readthedocs.io/en/latest/" style="display: block; margin: 0 auto;">
    <img src="docs/tephi/source/_static/tephi-logo-200-142.png"
         style="max-width: 40%;" alt="Tephi"></a><br>
 </h1>


### PR DESCRIPTION
This PR links the `tephi` logo to the `latest` rtd documentation.

@trexfeathers 