### PR TITLE
update setup.py for pypi

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 # Top-level files
-include COPYING COPYING.LESSER README.rst
+include COPYING COPYING.LESSER README.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,9 @@ exclude = '''
   | conf.py
 )
 '''
+
+[build-system]
+# Defined by PEP 518
+requires = ["setuptools>=40.8.0", "wheel"]
+# Defined by PEP 517
+build-backend = "setuptools.build_meta:__legacy__"

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,9 @@ args = dict(
     name=NAME,
     version=extract_version(),
     author="UK Met Office",
+    url="https://github.com/SciTools/tephi",
+    license="LGPLv3+",
+    keywords=["tephigram", "radiosonde", "meteorology",],
     packages=find_packages(),
     package_data={
         "tephi": [
@@ -62,10 +65,11 @@ args = dict(
     description="Tephigram plotting in Python",
     long_description=long_description(),
     long_description_content_type="text/markdown",
-    setup_requires=["setuptools>=40.8.0"],
+    setup_requires=["setuptools>=40.8.0", "pytest-runner"],
     install_requires=load("requirements.txt"),
     tests_require=load("requirements-dev.txt"),
     test_suite=f"{NAME}.tests",
+    python_requires=">=3.6",
 )
 
 


### PR DESCRIPTION
This PR reinstates the `pytest-runner` to allow `python setup.py test` to work, and adds additional PyPI metadata.