### PR TITLE
move to setup.cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
-<h1 align="center">
-  <a href="https://tephi.readthedocs.io/en/latest/" style="display: block; margin: 0 auto;">
-   <img src="https://scitools.github.io/tephi/tephi-logo-200-137.png"
-        style="max-width: 40%;" alt="Tephi"></a><br>
-</h1>
+<p align="center">
+<a href="https://tephi.readthedocs.io/en/latest/">
+    <img src="https://scitools.github.io/tephi/tephi-logo-200-137.png" alt="Tephi">
+</a>
+</p>
 
-<h4 align="center">
-    Tephigram plotting in Python 
-</h4>
+<p align="center"><strong>Tephigram plotting in Python</strong></p>
 
 <p align="center">
 <a href="https://travis-ci.org/github/SciTools/tephi/branches">

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[aliases]
-test = pytest
-
 [flake8]
 exclude =
     .git,
@@ -17,5 +14,57 @@ addopts =
     --cov-config=.coveragerc
     --cov=tephi
     --cov-report=term-missing
-#    --doctest-modules
+#   --doctest-modules
 #doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS
+
+[metadata]
+name = tephi
+version = attr: tephi.__version__
+author = UK Met Office
+author_email = scitools-iris-dev@googlegroups.com
+url = https://github.com/SciTools/tephi
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Science/Research
+    Operating System :: OS Independent
+    License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Topic :: Scientific/Engineering :: Atmospheric Science
+    Topic :: Scientific/Engineering :: Visualization
+license = LGPL-3.0
+license_file = COPYING.LESSER
+description = Tephigram plotting in Python
+long_description = file: README.md
+long_description_content_type = text/markdown
+project_urls =
+    code = https://github.com/SciTools/tephi
+    issues = https://github.com/SciTools/tephi/issues
+    binder = https://mybinder.org/v2/gh/SciTools/tephi/master?filepath=index.ipynb
+    documentation =  https://tephi.readthedocs.io/en/latest/
+keywords =
+    tephigram
+    radiosonde
+    meteorology
+    visualization
+
+[options]
+packages = find:
+setup_requires =
+    setuptools>=40.8.0
+    wheel
+install_requires =
+    matplotlib
+    numpy
+    scipy
+python_requires = >=3.6
+
+[options.package_data]
+tephi =
+  etc/test_data/*.txt
+  tests/results/*.npz
+  tests/results/imagerepo.json
+

--- a/setup.py
+++ b/setup.py
@@ -1,77 +1,12 @@
+#!/usr/bin/env python
 # Copyright Tephi contributors
 #
 # This file is part of Tephi and is released under the LGPL license.
 # See COPYING and COPYING.LESSER in the root of the repository for full
 # licensing details.
 
-
-import os
-from setuptools import find_packages, setup
-
-
-NAME = "tephi"
-DIR = os.path.abspath(os.path.dirname(__file__))
-
-
-def extract_version():
-    version = None
-    fname = os.path.join(DIR, NAME, "__init__.py")
-    with open(fname, "r") as fi:
-        for line in fi:
-            if line.startswith("__version__"):
-                _, version = line.split("=")
-                version = version.strip()[1:-1]  # Remove quotation characters
-                break
-    return version
-
-
-def load(fname):
-    result = []
-    with open(fname, "r") as fi:
-        result = [package.strip() for package in fi.readlines()]
-    return result
-
-
-def long_description():
-    with open(os.path.join(DIR, "README.md"), "r") as fi:
-        long_description = "".join(fi.readlines())
-    return long_description
-
-
-args = dict(
-    name=NAME,
-    version=extract_version(),
-    author="UK Met Office",
-    url="https://github.com/SciTools/tephi",
-    license="LGPLv3+",
-    keywords=["tephigram", "radiosonde", "meteorology",],
-    packages=find_packages(),
-    package_data={
-        "tephi": [
-            "etc/test_data/*.txt",
-            "tests/results/*.npz",
-            "tests/results/*.json",
-        ]
-    },
-    classifiers=[
-        "License :: OSI Approved :: "
-        "GNU Lesser General Public License v3 or later (LGPLv3+)",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-    ],
-    description="Tephigram plotting in Python",
-    long_description=long_description(),
-    long_description_content_type="text/markdown",
-    setup_requires=["setuptools>=40.8.0", "pytest-runner"],
-    install_requires=load("requirements.txt"),
-    tests_require=load("requirements-dev.txt"),
-    test_suite=f"{NAME}.tests",
-    python_requires=">=3.6",
-)
+from setuptools import setup
 
 
 if __name__ == "__main__":
-    setup(**args)
+    setup()


### PR DESCRIPTION
The PR tidies the `setup.py`, moving all of the `metadata` into `setup.cfg`.

Note that, since `setuptools` [41.5.0](https://setuptools.readthedocs.io/en/latest/history.html#v41-5-0) ([PR #1878](https://github.com/pypa/setuptools/pull/1878)) the `test` option, and `test_suite` and `tests_require` keywords have been deprecated.