### PR TITLE
Add scooby

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,6 +10,7 @@ omit =
     setup.py
     docs/*
     tephi/tests/*
+    tephi/utils/*
     .eggs
 
 [report]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 matplotlib
 numpy
 scipy
+scooby

--- a/tephi/__init__.py
+++ b/tephi/__init__.py
@@ -26,6 +26,7 @@ import os.path
 
 from . import isopleths
 from . import transforms
+from .utils.report import Report  # noqa
 
 
 __version__ = "0.3.0.dev0"

--- a/tephi/utils/__init__.py
+++ b/tephi/utils/__init__.py
@@ -1,0 +1,6 @@
+# Copyright Tephi contributors
+#
+# This file is part of Tephi and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""Miscellaneous support utilities for tephi."""

--- a/tephi/utils/report.py
+++ b/tephi/utils/report.py
@@ -1,0 +1,116 @@
+# Copyright Tephi contributors
+#
+# This file is part of Tephi and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""Platform and package dependency reporting."""
+
+import os
+from subprocess import check_output, CalledProcessError
+
+import scooby
+
+
+class CondaInfo:
+    """
+    Internal helper class to provision conda and conda environment
+    metadata.
+
+    """
+
+    def __init__(self):
+        self._path = None
+
+    @property
+    def version(self):
+        result = "Unknown"
+        if self._path is not None:
+            with open(os.devnull, "w") as null:
+                command = ["conda", "--version"]
+                try:
+                    result = check_output(command, stderr=null)
+                    result = result.decode("utf-8").split(" ")[1].strip()
+                except CalledProcessError:
+                    pass
+        return result
+
+    @property
+    def name(self):
+        result = "Unknown"
+        if self._path is not None:
+            result = os.environ.get("CONDA_DEFAULT_ENV", "base")
+        return result
+
+    @property
+    def packages(self):
+        result = "Unknown"
+        if self._path is not None:
+            with open(os.devnull, "w") as null:
+                command = ["conda", "list", "-n", self.name, "--explicit"]
+                try:
+                    result = check_output(command, stderr=null)
+                    lines = result.decode("utf-8").split("\n")
+                    lines = sorted(
+                        [
+                            line
+                            for line in lines
+                            if not (
+                                line.startswith("#") or line.startswith("@")
+                            )
+                            and line
+                        ]
+                    )
+                    result = "\n\t{}".format("\n\t".join(lines))
+                except CalledProcessError:
+                    pass
+        return result
+
+    def get_info(self):
+        self._path = os.environ.get("CONDA_EXE", None)
+        return (
+            (self.version, "Conda Version"),
+            (self.name, "Conda Environment"),
+            (self.packages, "Conda Packages"),
+        )
+
+
+class Report(scooby.Report):
+    """
+    Generate a :class:`scooby.Report` of platform and package dependencies.
+
+    Parameters
+    ----------
+    additional : list of ModuleType, list of str, optional
+        List of packages or package names to add to output information.
+    ncol : int, optional
+        Number of package-columns in HTML table. Has no effect in text-version
+        (default is 3).
+    text_width : int, optional
+        The text width for non-HTML display modes (default is 80).
+    sort : bool, optional
+        Sort the packages when the report is shown (default is False).
+    conda : bool, optional
+        Gather information about conda (default is False).
+
+    """
+
+    def __init__(
+        self, additional=None, ncol=3, text_width=80, sort=False, conda=False
+    ):
+        # Mandatory packages.
+        core = ["tephi", "matplotlib", "numpy", "scipy"]
+
+        # Gather conda information.
+        if conda:
+            extra_meta = CondaInfo().get_info()
+        else:
+            extra_meta = None
+
+        super().__init__(
+            additional=additional,
+            core=core,
+            ncol=ncol,
+            text_width=text_width,
+            sort=sort,
+            extra_meta=extra_meta,
+        )


### PR DESCRIPTION
This PR adds platform and package dependency reporting support. This will facilitate better support for user who raise issues, and allow them to easily reap a report of metadata that will help the developer assist them by providing some context to the users working environment.

For example,
```bash
>>> import tephi
>>> tephi.Report()

--------------------------------------------------------------------------------
  Date: Fri May 29 15:13:49 2020 BST

                OS : Linux
            CPU(s) : 4
           Machine : x86_64
      Architecture : 64bit
       Environment : Python

  Python 3.8.2 | packaged by conda-forge | (default, Apr 24 2020, 08:20:52)
  [GCC 7.3.0]

             tephi : 0.3.0.dev0
        matplotlib : 3.2.1
             numpy : 1.18.4
             scipy : 1.4.1
           IPython : 7.14.0
            scooby : 0.5.4
--------------------------------------------------------------------------------
```
And extended support for conda environments e.g.
```bash
>>> import tephi
>>> tephi.Report(conda=True)

--------------------------------------------------------------------------------
  Date: Fri May 29 15:17:28 2020 BST

                OS : Linux
            CPU(s) : 4
           Machine : x86_64
      Architecture : 64bit
       Environment : Python
     Conda Version : 4.7.12
 Conda Environment : tephi
    Conda Packages : 
	https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
	https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-1_llvm.tar.bz2
	...
        <snip>
        ...
	https://conda.anaconda.org/conda-forge/noarch/wheel-0.34.2-py_1.tar.bz2
	https://conda.anaconda.org/conda-forge/noarch/zipp-3.1.0-py_0.tar.bz2

  Python 3.8.2 | packaged by conda-forge | (default, Apr 24 2020, 08:20:52)
  [GCC 7.3.0]

             tephi : 0.3.0.dev0
        matplotlib : 3.2.1
             numpy : 1.18.4
             scipy : 1.4.1
           IPython : 7.14.0
            scooby : 0.5.4
--------------------------------------------------------------------------------
```