### PR TITLE
migrate unittest to pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,8 @@ exclude =
 [tool:pytest]
 testpaths =
     tephi/
+markers =
+    graphical: mark a test as a graphical test
 addopts =
     -ra
     -v

--- a/tephi/tests/__init__.py
+++ b/tephi/tests/__init__.py
@@ -22,11 +22,11 @@ import io
 import json
 import os
 import sys
-import unittest
 
 import filelock
 import matplotlib
 import numpy as np
+import pytest
 import requests
 
 from tephi import DATA_DIR
@@ -60,9 +60,9 @@ except requests.exceptions.ConnectionError:
     INET_AVAILABLE = False
 
 
-skip_inet = unittest.skipIf(
+requires_inet = pytest.mark.skipif(
     not INET_AVAILABLE,
-    ('Test(s) require an "internet connection", which is not available.'),
+    reason=('Test requires an "internet connection", which is not available.'),
 )
 
 
@@ -99,67 +99,31 @@ def get_result_path(relative_path):
     return os.path.abspath(os.path.join(_RESULT_PATH, relative_path))
 
 
-class TephiTest(unittest.TestCase):
+class TephiTest:
     """
-    A subclass of unittest.TestCase which provides testing functionality
-    specific to tephi.
+    Utility class containing common testing framework functionality.
 
     """
-
-    _assertion_counts = collections.defaultdict(int)
-
-    def _unique_id(self):
-        """
-        Returns the unique ID for the current assertion.
-
-        The ID is composed of two parts: a unique ID for the current test
-        (which is itself composed of the module, class, and test names), and
-        a sequential counter (specific to the current test) that is incremented
-        on each call.
-
-        For example, calls from a "test_tx" routine followed by a "test_ty"
-        routine might result in::
-            test_plot.TestContourf.test_tx.0
-            test_plot.TestContourf.test_tx.1
-            test_plot.TestContourf.test_tx.2
-            test_plot.TestContourf.test_ty.0
-
-        """
-        # Obtain a consistent ID for the current test.
-
-        # NB. unittest.TestCase.id() returns different values depending on
-        # whether the test has been run explicitly, or via test discovery.
-        # For example:
-        #   python tests/test_brand.py
-        #       => '__main__.TestBranding.test_combo'
-        #   python -m unittest discover
-        #       => 'tephi.tests.test_brand.TestBranding.test_combo'
-        bits = self.id().split(".")[-3:]
-        if bits[0] == "__main__":
-            file_name = os.path.basename(sys.modules["__main__"].__file__)
-            bits[0] = os.path.splitext(file_name)[0]
-        test_id = ".".join(bits)
-
-        # Derive the sequential assertion ID within the test
-        assertion_id = self._assertion_counts[test_id]
-        self._assertion_counts[test_id] += 1
-
-        return "{}.{}".format(test_id, assertion_id)
 
     def assertArrayEqual(self, a, b):
+        __tracebackhide__ = True
         return np.testing.assert_array_equal(a, b)
 
     def assertArrayAlmostEqual(self, a, b, *args, **kwargs):
+        __tracebackhide__ = True
         return np.testing.assert_array_almost_equal(a, b, *args, **kwargs)
 
 
 class GraphicsTest(TephiTest):
-    def tearDown(self):
-        # If a plotting test bombs out it can leave the current figure in an
-        # odd state, so we make sure it's been disposed of.
-        plt.close()
 
-    def check_graphic(self):
+    _assertion_count = collections.defaultdict(int)
+
+    def _unique_id(self, nodeid):
+        count = self._assertion_count[nodeid]
+        self._assertion_count[nodeid] += 1
+        return f"{nodeid}.{count}"
+
+    def check_graphic(self, nodeid):
         """
         Check the hash of the current matplotlib figure matches the expected
         image hash for the current graphic test.
@@ -170,11 +134,12 @@ class GraphicsTest(TephiTest):
         output directory, and the imagerepo.json file being updated.
 
         """
+        __tracebackhide__ = True
         import imagehash
         from PIL import Image
 
         dev_mode = os.environ.get("TEPHI_TEST_CREATE_MISSING")
-        unique_id = self._unique_id()
+        unique_id = self._unique_id(nodeid)
         repo_fname = os.path.join(_RESULT_PATH, "imagerepo.json")
         repo = {}
         if os.path.isfile(repo_fname):

--- a/tephi/tests/__init__.py
+++ b/tephi/tests/__init__.py
@@ -119,6 +119,22 @@ class GraphicsTest(TephiTest):
     _assertion_count = collections.defaultdict(int)
 
     def _unique_id(self, nodeid):
+        """Create a hashable key to represent the unique test invocation.
+
+        Construct the hashable key from the provided nodeid and a sequential
+        counter specific to the current test, that is incremented on each call.
+
+        Parameters
+        ----------
+        nodeid : str
+            Unique identifier for the current test. See :func:`nodeid` fixture.
+
+        Returns
+        -------
+        str
+            The nodeid with sequential counter.
+
+        """
         count = self._assertion_count[nodeid]
         self._assertion_count[nodeid] += 1
         return f"{nodeid}.{count}"

--- a/tephi/tests/conftest.py
+++ b/tephi/tests/conftest.py
@@ -11,8 +11,7 @@ import pytest
 
 @pytest.fixture
 def close_plot():
-    """
-    This fixture closes the matplotlib plot for a graphical test.
+    """This fixture closes the current matplotlib plot associated with the graphical test.
 
     """
     yield
@@ -21,8 +20,21 @@ def close_plot():
 
 @pytest.fixture
 def nodeid(request):
-    """
-    This fixture returns the unique test name.
+    """This fixture returns the unique test name for the method.
+
+    Constructs the nodeid, which is composed of the test module name,
+    class name, and method name.
+
+    Parameters
+    ----------
+    request : fixure
+        pytest built-in fixture providing information of the requesting
+        test function.
+
+    Returns
+    -------
+    str
+        The test nodeid consisting of the module, class and test name.
 
     """
     root = request.fspath.basename.split(".")[0]

--- a/tephi/tests/conftest.py
+++ b/tephi/tests/conftest.py
@@ -1,0 +1,31 @@
+# Copyright Tephi contributors
+#
+# This file is part of Tephi and is released under the LGPL license.
+# See COPYING and COPYING.LESSER in the root of the repository for full
+# licensing details.
+"""pytest configuration"""
+
+import matplotlib.pyplot as plt
+import pytest
+
+
+@pytest.fixture
+def close_plot():
+    """
+    This fixture closes the matplotlib plot for a graphical test.
+
+    """
+    yield
+    plt.close()
+
+
+@pytest.fixture
+def nodeid(request):
+    """
+    This fixture returns the unique test name.
+
+    """
+    root = request.fspath.basename.split(".")[0]
+    klass = request.cls.__name__
+    func = request.node.name
+    return f"{root}.{klass}.{func}"

--- a/tephi/tests/conftest.py
+++ b/tephi/tests/conftest.py
@@ -27,7 +27,7 @@ def nodeid(request):
 
     Parameters
     ----------
-    request : fixure
+    request : fixture
         pytest built-in fixture providing information of the requesting
         test function.
 
@@ -40,4 +40,4 @@ def nodeid(request):
     root = request.fspath.basename.split(".")[0]
     klass = request.cls.__name__
     func = request.node.name
-    return f"{root}.{klass}.{func}"
+    return ".".join([root, klass, func])

--- a/tephi/tests/test_imagerepo.py
+++ b/tephi/tests/test_imagerepo.py
@@ -16,7 +16,7 @@ import codecs
 import itertools
 import json
 import os
-import unittest
+import pytest
 
 import requests
 
@@ -27,13 +27,13 @@ IMAGE_MANIFEST = (
 )
 
 
-@tests.skip_inet
-class TestImageRepoJSON(tests.TephiTest):
+@tests.requires_inet
+class TestImageRepoJSON:
     def test(self):
         response = requests.get(IMAGE_MANIFEST)
 
         emsg = 'Failed to download "image_manifest.txt"'
-        self.assertEqual(response.status_code, requests.codes.ok, msg=emsg)
+        assert response.status_code == requests.codes.ok, emsg
 
         image_manifest = response.content.decode("utf-8")
         image_manifest = [line.strip() for line in image_manifest.split("\n")]
@@ -59,9 +59,4 @@ class TestImageRepoJSON(tests.TephiTest):
             )
             emsg = emsg.format(count, IMAGE_MANIFEST)
             emsg += "\t".join(uri for uri in missing)
-            # Always fails when we get here: report the problem.
-            self.assertEqual(count, 0, msg=emsg)
-
-
-if __name__ == "__main__":
-    unittest.main()
+            pytest.fail(emsg)

--- a/tephi/tests/test_tephigram.py
+++ b/tephi/tests/test_tephigram.py
@@ -11,9 +11,8 @@ Tests the tephigram plotting capability provided by tephi.
 # before importing anything else.
 import tephi.tests as tests
 
-import unittest
-
 import numpy as np
+import pytest
 
 import tephi
 from tephi import Tephigram
@@ -31,19 +30,20 @@ _expected_barbs = _load_result("barbs.npz")
 
 
 class TestTephigramLoadTxt(tests.TephiTest):
-    def setUp(self):
+    @pytest.fixture(autouse=True)
+    def setup(self):
         self.filename_dews = tephi.tests.get_data_path("dews.txt")
         self.filename_temps = tephi.tests.get_data_path("temps.txt")
         self.filename_barbs = tephi.tests.get_data_path("barbs.txt")
         self.filename_comma = tephi.tests.get_data_path("comma_sep.txt")
 
     def test_is_not_file(self):
-        with self.assertRaises(OSError):
+        with pytest.raises(OSError):
             tephi.loadtxt("wibble")
 
     def test_load_data_no_column_names(self):
         dews = tephi.loadtxt(self.filename_dews)
-        self.assertEqual(dews._fields, ("pressure", "temperature"))
+        assert dews._fields == ("pressure", "temperature")
         self.assertArrayEqual(dews.pressure, _expected_dews[0])
         self.assertArrayEqual(dews, _expected_dews)
 
@@ -51,7 +51,7 @@ class TestTephigramLoadTxt(tests.TephiTest):
         # Column titles test all valid namedtuple characters (alphanumeric, _).
         columns = ("pressure", "dewpoint2", "wind_speed", "WindDirection")
         barbs = tephi.loadtxt(self.filename_barbs, column_titles=columns)
-        self.assertEqual(barbs._fields, columns)
+        assert barbs._fields == columns
         self.assertArrayEqual(barbs.wind_speed, _expected_barbs[2])
         self.assertArrayEqual(barbs, _expected_barbs)
 
@@ -60,31 +60,31 @@ class TestTephigramLoadTxt(tests.TephiTest):
         dews, temps = tephi.loadtxt(
             self.filename_dews, self.filename_temps, column_titles=columns
         )
-        self.assertEqual(dews._fields, columns)
-        self.assertEqual(temps._fields, columns)
+        assert dews._fields == columns
+        assert temps._fields == columns
 
     def test_load_data_too_many_column_iterables(self):
         columns = [
             ("pressure", "dewpoint"),
             ("pressure", "wind_speed", "wind_direction"),
         ]
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             tephi.loadtxt(self.filename_dews, column_titles=columns)
 
     def test_number_of_columns_and_titles_not_equal(self):
         columns = ("pressure", "dewpoint", "wind_speed")
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             tephi.loadtxt(self.filename_barbs, column_titles=columns)
 
     def test_invalid_column_titles(self):
         columns = ("pres-sure", "dew+point", 5)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             tephi.loadtxt(self.filename_dews, column_titles=columns)
 
     def test_non_iterable_column_title(self):
         # For the case of column titles, strings are considered non-iterable.
         columns = "pressure"
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             tephi.loadtxt(self.filename_dews, column_titles=columns)
 
     def test_delimiter(self):
@@ -92,132 +92,138 @@ class TestTephigramLoadTxt(tests.TephiTest):
         data = tephi.loadtxt(
             self.filename_comma, column_titles=columns, delimiter=","
         )
-        self.assertEqual(data.pressure.shape, (2,))
+        assert data.pressure.shape == (2,)
 
     def test_dtype(self):
         dews = tephi.loadtxt(self.filename_dews, dtype="i4")
-        self.assertIsInstance(dews.pressure[0], np.int32)
-        self.assertIsInstance(dews.temperature[0], np.int32)
+        assert dews.pressure[0].dtype == np.int32
+        assert dews.temperature[0].dtype == np.int32
 
 
+@pytest.mark.usefixtures("close_plot", "nodeid")
 class TestTephigramPlot(tests.GraphicsTest):
-    def setUp(self):
+    @pytest.fixture(autouse=True)
+    def setup(self):
         self.dews = _expected_dews.T
         self.temps = _expected_temps.T
 
-    def test_plot_dews(self):
-        tpg = Tephigram()
-        tpg.plot(self.dews)
-        self.check_graphic()
+    def test_plot_dews(self, nodeid):
+        tephigram = Tephigram()
+        tephigram.plot(self.dews)
+        self.check_graphic(nodeid)
 
-    def test_plot_temps(self):
-        tpg = Tephigram()
-        tpg.plot(self.temps)
-        self.check_graphic()
+    def test_plot_temps(self, nodeid):
+        tephigram = Tephigram()
+        tephigram.plot(self.temps)
+        self.check_graphic(nodeid)
 
-    def test_plot_dews_temps(self):
-        tpg = Tephigram()
-        tpg.plot(self.dews)
-        tpg.plot(self.temps)
-        self.check_graphic()
+    def test_plot_dews_temps(self, nodeid):
+        tephigram = Tephigram()
+        tephigram.plot(self.dews)
+        tephigram.plot(self.temps)
+        self.check_graphic(nodeid)
 
-    def test_plot_dews_label(self):
-        tpg = Tephigram()
-        tpg.plot(self.dews, label="Dew-point temperature")
-        self.check_graphic()
+    def test_plot_dews_label(self, nodeid):
+        tephigram = Tephigram()
+        tephigram.plot(self.dews, label="Dew-point temperature")
+        self.check_graphic(nodeid)
 
-    def test_plot_temps_label(self):
-        tpg = Tephigram()
-        tpg.plot(self.temps, label="Dry-bulb temperature")
-        self.check_graphic()
+    def test_plot_temps_label(self, nodeid):
+        tephigram = Tephigram()
+        tephigram.plot(self.temps, label="Dry-bulb temperature")
+        self.check_graphic(nodeid)
 
-    def test_plot_dews_custom(self):
-        tpg = Tephigram()
-        tpg.plot(
+    def test_plot_dews_custom(self, nodeid):
+        tephigram = Tephigram()
+        tephigram.plot(
             self.dews,
             label="Dew-point temperature",
             linewidth=2,
             color="blue",
             marker="s",
         )
-        self.check_graphic()
+        self.check_graphic(nodeid)
 
-    def test_plot_temps_custom(self):
-        tpg = Tephigram()
-        tpg.plot(
+    def test_plot_temps_custom(self, nodeid):
+        tephigram = Tephigram()
+        tephigram.plot(
             self.temps,
             label="Dry-bulb temperature",
             linewidth=2,
             color="red",
             marker="o",
         )
-        self.check_graphic()
+        self.check_graphic(nodeid)
 
-    def test_plot_dews_temps_custom(self):
-        tpg = Tephigram()
-        tpg.plot(
+    def test_plot_dews_temps_custom(self, nodeid):
+        tephigram = Tephigram()
+        tephigram.plot(
             self.dews,
             label="Dew-point temperature",
             linewidth=2,
             color="blue",
             marker="s",
         )
-        tpg.plot(
+        tephigram.plot(
             self.temps,
             label="Dry-bulb temperature",
             linewidth=2,
             color="red",
             marker="o",
         )
-        self.check_graphic()
+        self.check_graphic(nodeid)
 
-    def test_plot_dews_locator_isotherm_numeric(self):
-        tpg = Tephigram(isotherm_locator=10)
-        tpg.plot(self.dews)
-        self.check_graphic()
+    def test_plot_dews_locator_isotherm_numeric(self, nodeid):
+        tephigram = Tephigram(isotherm_locator=10)
+        tephigram.plot(self.dews)
+        self.check_graphic(nodeid)
 
-    def test_plot_dews_locator_isotherm_object(self):
-        tpg = Tephigram(isotherm_locator=tephi.Locator(10))
-        tpg.plot(self.dews)
-        self.check_graphic()
+    def test_plot_dews_locator_isotherm_object(self, nodeid):
+        tephigram = Tephigram(isotherm_locator=tephi.Locator(10))
+        tephigram.plot(self.dews)
+        self.check_graphic(nodeid)
 
-    def test_plot_dews_locator_adiabat_numeric(self):
-        tpg = Tephigram(dry_adiabat_locator=10)
-        tpg.plot(self.dews)
-        self.check_graphic()
+    def test_plot_dews_locator_adiabat_numeric(self, nodeid):
+        tephigram = Tephigram(dry_adiabat_locator=10)
+        tephigram.plot(self.dews)
+        self.check_graphic(nodeid)
 
-    def test_plot_dews_locator_adiabat_object(self):
-        tpg = Tephigram(dry_adiabat_locator=tephi.Locator(10))
-        tpg.plot(self.dews)
-        self.check_graphic()
+    def test_plot_dews_locator_adiabat_object(self, nodeid):
+        tephigram = Tephigram(dry_adiabat_locator=tephi.Locator(10))
+        tephigram.plot(self.dews)
+        self.check_graphic(nodeid)
 
-    def test_plot_dews_locator_numeric(self):
-        tpg = Tephigram(isotherm_locator=10, dry_adiabat_locator=10)
-        tpg.plot(self.dews)
-        self.check_graphic()
+    def test_plot_dews_locator_numeric(self, nodeid):
+        tephigram = Tephigram(isotherm_locator=10, dry_adiabat_locator=10)
+        tephigram.plot(self.dews)
+        self.check_graphic(nodeid)
 
-    def test_plot_dews_locator_object(self):
+    def test_plot_dews_locator_object(self, nodeid):
         locator = tephi.Locator(10)
-        tpg = Tephigram(isotherm_locator=locator, dry_adiabat_locator=locator)
-        tpg.plot(self.dews)
-        self.check_graphic()
+        tephigram = Tephigram(
+            isotherm_locator=locator, dry_adiabat_locator=locator
+        )
+        tephigram.plot(self.dews)
+        self.check_graphic(nodeid)
 
-    def test_plot_anchor(self):
-        tpg = Tephigram(anchor=[(1000, 0), (300, 0)])
-        tpg.plot(self.dews)
-        self.check_graphic()
+    def test_plot_anchor(self, nodeid):
+        tephigram = Tephigram(anchor=[(1000, 0), (300, 0)])
+        tephigram.plot(self.dews)
+        self.check_graphic(nodeid)
 
 
+@pytest.mark.usefixtures("close_plot", "nodeid")
 class TestTephigramBarbs(tests.GraphicsTest):
-    def setUp(self):
+    @pytest.fixture(autouse=True)
+    def setup(self):
         self.dews = _expected_dews.T
         self.temps = _expected_temps.T
         magnitude = np.hstack(([0], np.arange(20) * 5 + 2, [102]))
         self.barbs = [(m, 45, 1000 - i * 35) for i, m in enumerate(magnitude)]
 
-    def test_rotate(self):
-        tpg = Tephigram()
-        profile = tpg.plot(self.temps)
+    def test_rotate(self, nodeid):
+        tephigram = Tephigram()
+        profile = tephigram.plot(self.temps)
         profile.barbs(
             [
                 (0, 0, 900),
@@ -236,50 +242,46 @@ class TestTephigramBarbs(tests.GraphicsTest):
             ],
             zorder=10,
         )
-        self.check_graphic()
+        self.check_graphic(nodeid)
 
-    def test_barbs(self):
-        tpg = Tephigram()
-        profile = tpg.plot(self.temps)
+    def test_barbs(self, nodeid):
+        tephigram = Tephigram()
+        profile = tephigram.plot(self.temps)
         profile.barbs(self.barbs, zorder=10)
-        self.check_graphic()
+        self.check_graphic(nodeid)
 
-    def test_barbs_from_file(self):
-        tpg = Tephigram()
+    def test_barbs_from_file(self, nodeid):
+        tephigram = Tephigram()
         dews = _expected_barbs.T[:, :2]
         barbs = np.column_stack(
             (_expected_barbs[2], _expected_barbs[3], _expected_barbs[0])
         )
-        profile = tpg.plot(dews)
+        profile = tephigram.plot(dews)
         profile.barbs(barbs, zorder=10)
-        self.check_graphic()
+        self.check_graphic(nodeid)
 
-    def test_gutter(self):
-        tpg = Tephigram()
-        profile = tpg.plot(self.temps)
+    def test_gutter(self, nodeid):
+        tephigram = Tephigram()
+        profile = tephigram.plot(self.temps)
         profile.barbs(self.barbs, gutter=0.5, zorder=10)
-        self.check_graphic()
+        self.check_graphic(nodeid)
 
-    def test_length(self):
-        tpg = Tephigram()
-        profile = tpg.plot(self.temps)
+    def test_length(self, nodeid):
+        tephigram = Tephigram()
+        profile = tephigram.plot(self.temps)
         profile.barbs(self.barbs, gutter=0.9, length=10, zorder=10)
-        self.check_graphic()
+        self.check_graphic(nodeid)
 
-    def test_color(self):
-        tpg = Tephigram()
-        profile = tpg.plot(self.temps)
+    def test_color(self, nodeid):
+        tephigram = Tephigram()
+        profile = tephigram.plot(self.temps)
         profile.barbs(self.barbs, color="green", zorder=10)
-        self.check_graphic()
+        self.check_graphic(nodeid)
 
-    def test_pivot(self):
-        tpg = Tephigram()
-        tprofile = tpg.plot(self.temps)
+    def test_pivot(self, nodeid):
+        tephigram = Tephigram()
+        tprofile = tephigram.plot(self.temps)
         tprofile.barbs(self.barbs, gutter=0.2, pivot="tip", length=8)
-        dprofile = tpg.plot(self.dews)
+        dprofile = tephigram.plot(self.dews)
         dprofile.barbs(self.barbs, gutter=0.3, pivot="middle", length=8)
-        self.check_graphic()
-
-
-if __name__ == "__main__":
-    unittest.main()
+        self.check_graphic(nodeid)

--- a/tephi/tests/test_tephigram.py
+++ b/tephi/tests/test_tephigram.py
@@ -100,6 +100,7 @@ class TestTephigramLoadTxt(tests.TephiTest):
         assert dews.temperature[0].dtype == np.int32
 
 
+@pytest.mark.graphical
 @pytest.mark.usefixtures("close_plot", "nodeid")
 class TestTephigramPlot(tests.GraphicsTest):
     @pytest.fixture(autouse=True)
@@ -212,6 +213,7 @@ class TestTephigramPlot(tests.GraphicsTest):
         self.check_graphic(nodeid)
 
 
+@pytest.mark.graphical
 @pytest.mark.usefixtures("close_plot", "nodeid")
 class TestTephigramBarbs(tests.GraphicsTest):
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
This PR replaces the use of `unittest` with `pytest`.

@trexfeathers I'd like you to take the time to understand and actually review this PR.

It will be an ideal way to introduce you to the wonders of `pytest` :smile: 