### PR TITLE
git ignore updates

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,1 @@
+a7f3f8fada3ff9bec3a3adf461ba0245a7a77340

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ docs/_build/
 docs/tephi/source/api
 # misc
 *.lock
+
+tephi_image_test_output


### PR DESCRIPTION
- Ignore the commit in `git blame` that first applied black to the codebase
- Ignore the test image output folder