### PR TITLE
Update badges master to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,41 +6,45 @@
 
 <p align="center"><strong>Tephigram plotting in Python</strong></p>
 
-<a href="https://readthedocs.org/projects/tephi/">
+<p align="center">
+  <a href="https://readthedocs.org/projects/tephi/">
     <img src="https://readthedocs.org/projects/tephi/badge/?version=latest"
-        alt="Documentation Status" />
-</a>
-<a href="https://coveralls.io/github/SciTools/tephi?branch=main">
+         alt="Documentation Status" />
+  </a>
+  <a href="https://coveralls.io/github/SciTools/tephi?branch=main">
     <img src="https://coveralls.io/repos/github/SciTools/tephi/badge.svg?branch=main"
-        alt="Coverage Status" />
-</a>
-<a href="https://github.com/SciTools/tephi/releases">
-    <img src="https://img.shields.io/github/v/tag/scitools/tephi?color=orange"
-        alt="GitHub tag (latest by date)" />
-</a>
-<a href="https://github.com/SciTools/tephi/commits/main">
-    <img src="https://img.shields.io/github/commits-since/scitools/tephi/latest/main"
-        alt="GitHub commits since tagged version" />
-</a>
-<a href="https://anaconda.org/conda-forge/tephi">
-    <img src="https://img.shields.io/conda/vn/conda-forge/tephi"
-        alt="conda-forge" />
-</a>
-<a href="https://pypi.org/project/tephi/">
-    <img src="https://img.shields.io/pypi/v/tephi"
-        alt="PyPI" />
-</a>
-<a href="https://mybinder.org/v2/gh/SciTools/tephi/main?filepath=index.ipynb">
-    <img src="https://mybinder.org/badge_logo.svg"
-        alt="Launch MyBinderk" />
-</a>
-<a href="https://github.com/psf/black">
+         alt="Coverage Status" />
+  </a>
+  <a href="https://github.com/psf/black">
     <img src="https://img.shields.io/badge/code/style-black-000000.svg"
          alt="Black" />
-</a>
-<a href="https://results.pre-commit.ci/latest/github/SciTools/tephi/main">
+  </a>
+  <a href="https://results.pre-commit.ci/latest/github/SciTools/tephi/main">
     <img src="https://results.pre-commit.ci/badge/github/SciTools/tephi/main.svg"
          alt="pre-commit.ci status">
+  </a>
+  <a href="https://mybinder.org/v2/gh/SciTools/tephi/main?filepath=index.ipynb">
+    <img src="https://mybinder.org/badge_logo.svg"
+         alt="Launch MyBinder" />
+  </a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/SciTools/tephi/releases">
+    <img src="https://img.shields.io/github/v/tag/scitools/tephi?color=orange"
+         alt="GitHub tag (latest by date)" />
+    </a>
+  <a href="https://github.com/SciTools/tephi/commits/main">
+    <img src="https://img.shields.io/github/commits-since/scitools/tephi/latest/main"
+         alt="GitHub commits since tagged version" />
+  </a>
+  <a href="https://anaconda.org/conda-forge/tephi">
+    <img src="https://img.shields.io/conda/vn/conda-forge/tephi"
+         alt="conda-forge" />
+  </a>
+  <a href="https://pypi.org/project/tephi/">
+    <img src="https://img.shields.io/pypi/v/tephi"
+         alt="PyPI" />
   </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -6,25 +6,20 @@
 
 <p align="center"><strong>Tephigram plotting in Python</strong></p>
 
-<p align="center">
-<a href="https://travis-ci.org/github/SciTools/tephi/branches">
-    <img src="https://travis-ci.org/SciTools/tephi.svg?branch=master"
-        alt="Travis-CI" />
-</a>
-<a href="https://tephi.readthedocs.io/en/latest/?badge=latest">
+<a href="https://readthedocs.org/projects/tephi/">
     <img src="https://readthedocs.org/projects/tephi/badge/?version=latest"
         alt="Documentation Status" />
 </a>
-<a href="https://coveralls.io/github/SciTools/tephi?branch=master">
-    <img src="https://coveralls.io/repos/github/SciTools/tephi/badge.svg?branch=master"
+<a href="https://coveralls.io/github/SciTools/tephi?branch=main">
+    <img src="https://coveralls.io/repos/github/SciTools/tephi/badge.svg?branch=main"
         alt="Coverage Status" />
 </a>
 <a href="https://github.com/SciTools/tephi/releases">
     <img src="https://img.shields.io/github/v/tag/scitools/tephi?color=orange"
         alt="GitHub tag (latest by date)" />
 </a>
-<a href="https://github.com/SciTools/tephi/commits/master">
-    <img src="https://img.shields.io/github/commits-since/scitools/tephi/latest/master"
+<a href="https://github.com/SciTools/tephi/commits/main">
+    <img src="https://img.shields.io/github/commits-since/scitools/tephi/latest/main"
         alt="GitHub commits since tagged version" />
 </a>
 <a href="https://anaconda.org/conda-forge/tephi">
@@ -35,7 +30,7 @@
     <img src="https://img.shields.io/pypi/v/tephi"
         alt="PyPI" />
 </a>
-<a href="https://mybinder.org/v2/gh/SciTools/tephi/master?filepath=index.ipynb">
+<a href="https://mybinder.org/v2/gh/SciTools/tephi/main?filepath=index.ipynb">
     <img src="https://mybinder.org/badge_logo.svg"
         alt="Launch MyBinderk" />
 </a>
@@ -43,6 +38,10 @@
     <img src="https://img.shields.io/badge/code/style-black-000000.svg"
          alt="Black" />
 </a>
+<a href="https://results.pre-commit.ci/latest/github/SciTools/tephi/main">
+    <img src="https://results.pre-commit.ci/badge/github/SciTools/tephi/main.svg"
+         alt="pre-commit.ci status">
+  </a>
 </p>
 
 <br>

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ long_description_content_type = text/markdown
 project_urls =
     code = https://github.com/SciTools/tephi
     issues = https://github.com/SciTools/tephi/issues
-    binder = https://mybinder.org/v2/gh/SciTools/tephi/master?filepath=index.ipynb
+    binder = https://mybinder.org/v2/gh/SciTools/tephi/main?filepath=index.ipynb
     documentation =  https://tephi.readthedocs.io/en/latest/
 keywords =
     tephigram


### PR DESCRIPTION
Notices that some of the badges weren't rendering correctly after migrating `master` to `main`.

Also, re-synched `coveralls` on the server-side and reconfigured the primary branch to be `main` instead... hopefully the badge picks up a report once it's posted on merge.