### PR TITLE
fix np.object deprecation

### DIFF
--- a/tephi/isopleths.py
+++ b/tephi/isopleths.py
@@ -26,7 +26,7 @@ _BARB_GUTTER = 0.1
 _BARB_DTYPE = np.dtype(
     dict(
         names=("speed", "angle", "pressure", "barb"),
-        formats=("f4", "f4", "f4", np.object),
+        formats=("f4", "f4", "f4", object),
     )
 )
 


### PR DESCRIPTION
This PR fixes the [numpy 1.20.0 deprecation](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations) for `numpy.object` i.e., avoids the following warning being generated:

```
tephi/isopleths.py:29
  /tmp/persistent/itwl/git/tephi/tephi/isopleths.py:29: DeprecationWarning: `np.object` is a deprecated alias for the builtin `object`. To silence this warning, use `object` by itself. Doing this will not modify any behavior and is safe. 
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    formats=("f4", "f4", "f4", np.object),
```
