### PR TITLE
tidy and automate manifest check

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -1,0 +1,39 @@
+# Reference:
+#   - https://github.com/actions/checkout
+#   - https://pypa.github.io/pipx/docs/
+
+name: manifest
+
+on:
+  pull_request:
+    branches:
+      - "*"
+
+  push:
+    branches-ignore:
+      - "conda-lock-auto-update"
+      - "pre-commit-ci-update-config"
+      - "dependabot/*"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  manifest:
+    name: "check-manifest"
+
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: "check-manifest"
+        run: |
+          pipx run check-manifest

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -2,7 +2,7 @@
 #   - https://github.com/actions/checkout
 #   - https://pypa.github.io/pipx/docs/
 
-name: manifest
+name: Check manifest
 
 on:
   pull_request:

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,15 +1,16 @@
-exclude .coveragerc
-exclude .flake8
-exclude .git-blame-ignore-revs
 prune .github
-exclude .gitignore
-exclude .pre-commit-config.yaml
-exclude .readthedocs.yml
 include COPYING
-prune ci
-prune docs
-exclude environment.yml
-exclude index.ipynb
-prune tephi/etc
-prune tephi/tests
-exclude tox.ini
+include *.ipynb
+include *.yaml
+include *.yml
+include .coveragerc
+include .flake8
+include .git-blame-ignore-revs
+include tox.ini
+recursive-include ci *.yml
+recursive-include docs *.bat
+recursive-include docs *.ico
+recursive-include docs *.png
+recursive-include docs *.py
+recursive-include docs *.rst
+recursive-include docs Makefile

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,15 @@
-# Top-level files
-include COPYING COPYING.LESSER README.md
+exclude .coveragerc
+exclude .flake8
+exclude .git-blame-ignore-revs
+prune .github
+exclude .gitignore
+exclude .pre-commit-config.yaml
+exclude .readthedocs.yml
+include COPYING
+prune ci
+prune docs
+exclude environment.yml
+exclude index.ipynb
+prune tephi/etc
+prune tephi/tests
+exclude tox.ini

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,3 +63,8 @@ install_requires =
     scipy
 python_requires = >=3.6
 
+[options.package_data]
+tephi =
+  etc/test_data/*.txt
+  tests/results/*.npz
+  tests/results/imagerepo.json

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,8 +37,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Topic :: Scientific/Engineering :: Atmospheric Science
     Topic :: Scientific/Engineering :: Visualization
-license = LGPL-3.0
-license_file = COPYING.LESSER
+license_files = COPYING.LESSER
 description = Tephigram plotting in Python
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -63,10 +62,4 @@ install_requires =
     numpy
     scipy
 python_requires = >=3.6
-
-[options.package_data]
-tephi =
-  etc/test_data/*.txt
-  tests/results/*.npz
-  tests/results/imagerepo.json
 


### PR DESCRIPTION
This PR automates the task of PyPI manifest checking as part of our CI.

It also includes:
* rationalising the `MANIFEST.in`
* removing the `setuptools` deprecated use of `license` from `setup.cfg`, in favour of the recommended trove classifier, see [here](https://setuptools.pypa.io/en/latest/deprecated/distutils/setupscript.html?highlight=license#additional-meta-data)
* replacing the `setuptools` deprecated use of `license_file` for `license_files`, see [here](https://setuptools.pypa.io/en/latest/history.html?highlight=license_file#id348)