### PR TITLE
Fix docstrings with incorrect anchor order

### DIFF
--- a/tephi/__init__.py
+++ b/tephi/__init__.py
@@ -595,7 +595,7 @@ class Tephigram:
             A :class:`tephi.Locator` instance or a numeric step size
             for the dry adiabat lines.
         * anchor:
-            A sequence of two pressure, temperature pairs specifying the extent
+            A sequence of two pressure-temperature pairs specifying the extent
             of the tephigram plot in terms of the bottom right-hand corner, and
             the top left-hand corner. Pressure data points must be in units of
             mb or hPa, and temperature data points must be in units of degC.
@@ -839,7 +839,7 @@ class Tephigram:
 
         Args:
 
-        * data: pressure and temperature pair data points.
+        * data: pressure-temperature pair data points.
 
         .. note::
             All keyword arguments are passed through to

--- a/tephi/__init__.py
+++ b/tephi/__init__.py
@@ -595,7 +595,7 @@ class Tephigram:
             A :class:`tephi.Locator` instance or a numeric step size
             for the dry adiabat lines.
         * anchor:
-            A sequence of two pressure-temperature pairs specifying the extent
+            A sequence of two (pressure, temperature) pairs specifying the extent
             of the tephigram plot in terms of the bottom right-hand corner, and
             the top left-hand corner. Pressure data points must be in units of
             mb or hPa, and temperature data points must be in units of degC.
@@ -839,7 +839,7 @@ class Tephigram:
 
         Args:
 
-        * data: pressure-temperature pair data points.
+        * data: (pressure, temperature) pair data points.
 
         .. note::
             All keyword arguments are passed through to

--- a/tephi/__init__.py
+++ b/tephi/__init__.py
@@ -596,8 +596,8 @@ class Tephigram:
             for the dry adiabat lines.
         * anchor:
             A sequence of two pressure, temperature pairs specifying the extent
-            of the tephigram plot in terms of the bottom left hand corner and
-            the top right hand corner. Pressure data points must be in units of
+            of the tephigram plot in terms of the bottom right-hand corner, and
+            the top left-hand corner. Pressure data points must be in units of
             mb or hPa, and temperature data points must be in units of degC.
 
         For example:
@@ -801,9 +801,9 @@ class Tephigram:
                 or len(self._anchor) != 2
             ):
                 msg = (
-                    "Invalid anchor, expecting [(bottom-left-pressure, "
-                    "bottom-left-temperature), (top-right-pressure, "
-                    "top-right-temperature)]"
+                    "Invalid anchor, expecting [(bottom-right-pressure, "
+                    "bottom-right-temperature), (top-left-pressure, "
+                    "top-left-temperature)]"
                 )
                 raise ValueError(msg)
             (

--- a/tephi/isopleths.py
+++ b/tephi/isopleths.py
@@ -140,7 +140,7 @@ def _wet_adiabat_gradient(min_temperature, pressure, temperature, dp):
         calculate the gradient difference.
 
     Returns:
-        The gradient change as a pressure-potential_temperature value pair.
+        The gradient change as a (pressure, potential-temperature) value pair.
 
     """
 

--- a/tephi/isopleths.py
+++ b/tephi/isopleths.py
@@ -140,7 +140,7 @@ def _wet_adiabat_gradient(min_temperature, pressure, temperature, dp):
         calculate the gradient difference.
 
     Returns:
-        The gradient change as a pressure, potential temperature value pair.
+        The gradient change as a pressure-potential_temperature value pair.
 
     """
 
@@ -416,7 +416,7 @@ class Profile:
         if self.data.ndim != 2 or self.data.shape[-1] != 2:
             msg = (
                 "The environment profile data requires to be a sequence "
-                "of pressure, temperature value pairs."
+                "of pressure-temperature value pairs."
             )
             raise ValueError(msg)
         self.axes = axes

--- a/tephi/isopleths.py
+++ b/tephi/isopleths.py
@@ -416,7 +416,7 @@ class Profile:
         if self.data.ndim != 2 or self.data.shape[-1] != 2:
             msg = (
                 "The environment profile data requires to be a sequence "
-                "of pressure-temperature value pairs."
+                "of (pressure, temperature) value pairs."
             )
             raise ValueError(msg)
         self.axes = axes


### PR DESCRIPTION
## **Pull Request**

#### Closes #73.

- Docstrings updated to reference correct anchor order
- Also added consistency to "temperature - pressure pair" references to always be hyphenated.