### PR TITLE
Fix order of legend, so plot doesn't overlap

### DIFF
--- a/tephi/isopleths.py
+++ b/tephi/isopleths.py
@@ -445,7 +445,7 @@ class Profile:
             self.axes.lines.remove(self.line)
 
         if "zorder" not in kwargs:
-            kwargs["zorder"] = 10
+            kwargs["zorder"] = 4
 
         (self.line,) = self.axes.plot(
             self.temperature, self.theta, transform=self._transform, **kwargs

--- a/tephi/isopleths.py
+++ b/tephi/isopleths.py
@@ -368,6 +368,8 @@ class Barbs:
 
         """
         self._gutter = kwargs.pop("gutter", _BARB_GUTTER)
+        # zorder of 4.1 is higher than all MPL defaults, excluding legend. Also
+        # higher than tephi default for plot-lines.
         self._kwargs = dict(length=7, zorder=4.1)
         self._kwargs.update(kwargs)
         self._custom_kwargs = dict(
@@ -444,6 +446,7 @@ class Profile:
         if self.line is not None and self.line in self.axes.lines:
             self.axes.lines.remove(self.line)
 
+        # zorder of 4 is higher than all MPL defaults, excluding legend.
         if "zorder" not in kwargs:
             kwargs["zorder"] = 4
 

--- a/tephi/isopleths.py
+++ b/tephi/isopleths.py
@@ -368,7 +368,7 @@ class Barbs:
 
         """
         self._gutter = kwargs.pop("gutter", _BARB_GUTTER)
-        self._kwargs = dict(length=7, zorder=10)
+        self._kwargs = dict(length=7, zorder=4.1)
         self._kwargs.update(kwargs)
         self._custom_kwargs = dict(
             color=None, linewidth=1.5, zorder=self._kwargs["zorder"]


### PR DESCRIPTION
### Pull Request
Closes #55.

### Description
Default zorder for plots has been changed to 4. 
Default zorder for barbs has been changed to 4.1, slightly above plot-lines. 
These were chosen based on the MatPlotLib defaults, see [here](https://matplotlib.org/stable/gallery/misc/zorder_demo.html).

