### PR TITLE
adopt reusable ci-manifest gha

### DIFF
--- a/.github/workflows/ci-manifest.yml
+++ b/.github/workflows/ci-manifest.yml
@@ -1,6 +1,5 @@
-# Reference:
-#   - https://github.com/actions/checkout
-#   - https://pypa.github.io/pipx/docs/
+# Reference
+#    - https://github.com/actions/checkout
 
 name: ci-manifest
 
@@ -11,9 +10,11 @@ on:
 
   push:
     branches-ignore:
-      - "conda-lock-auto-update"
+      - "auto-update-lockfiles"
       - "pre-commit-ci-update-config"
       - "dependabot/*"
+
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -22,18 +23,4 @@ concurrency:
 jobs:
   manifest:
     name: "check-manifest"
-
-    runs-on: ubuntu-latest
-
-    defaults:
-      run:
-        shell: bash -l {0}
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: "check-manifest"
-        run: |
-          pipx run check-manifest
+    uses: scitools/workflows/.github/workflows/ci-manifest.yml@2023.04.1


### PR DESCRIPTION
This PR migrates the `ci-manifest` GHA to the `SciTools/workflows` reusable GHA.