### PR TITLE
Added stale gha

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,65 @@
+name: "Close stale issues and PRs"
+on:
+  schedule:
+    # daily
+    - cron: "0 0 * * *"
+
+env:
+  # 6 months
+  DAYS_BEFORE_STALE: 168
+  # 1 month
+  DAYS_BEFORE_CLOSE: 28
+
+jobs:
+  stale:
+    if: "github.repository == 'SciTools/tephi'"
+    runs-on: ubuntu-latests
+
+    steps:
+      - uses: actions/stale@v8
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          days-before-stale: ${{ env.DAYS_BEFORE_STALE }}
+          days-before-close: ${{ env.DAYS_BEFORE_CLOSE }}
+
+
+          stale-issue-message: |
+            In order to maintain a backlog of relevant issues, we automatically label them as stale after ${{ env.DAYS_BEFORE_STALE }} days of inactivity.
+            If this issue is still important to you, then please comment on this issue and the stale label will be removed.
+            Otherwise this issue will be automatically closed in ${{ env.DAYS_BEFORE_CLOSE }} days time.
+          stale-pr-message: |
+            In order to maintain a backlog of relevant PRs, we automatically label them as stale after ${{ env.DAYS_BEFORE_STALE }} days of inactivity.
+            If this PR is still important to you, then please comment on this PR and the stale label will be removed.
+            Otherwise this PR will be automatically closed in ${{ env.DAYS_BEFORE_CLOSE }} days time.
+
+          close-issue-message: |
+            This stale issue has been automatically closed due to a lack of community activity.
+            
+            If you still care about this issue, then please either:
+              * Re-open this issue, if you have sufficient permissions, or
+              * Add a comment pinging `@SciTools/tephi-maintainers` who will re-open on your behalf.
+          close-pr-message: |
+            This stale PR has been automatically closed due to a lack of community activity.
+            
+            If you still care about this PR, then please either:
+              * Re-open this PR, if you have sufficient permissions, or
+              * Add a comment pinging `@SciTools/tephi-maintainers` who will re-open on your behalf.
+
+          stale-issue-label: Stale
+          stale-pr-label: Stale
+
+          # Labels exempted from stale.
+          exempt-issue-labels: "Status: Blocked,Status: Decision Required"
+          exempt-pr-labels: "Status: Blocked,Status: Decision Required"
+
+          # Exempt all issues/prs with milestones from stale.
+          exempt-all-milestones: true
+
+          remove-stale-when-updated: true
+
+          # Max number of operations per run.
+          operations-per-run: 300
+
+          # Order to get issues/PRs.
+          ascending: true


### PR DESCRIPTION
Added the "stale" github action, to automatically:

* Mark a PR/issue as `Stale` if it has been inactive for **6 months** *(168 days)*
* Close a `Stale` PR/issue if it has had no further activity for **1 month** *(28 days)*

***Template altered from SciTools/python-stratify***