### PR TITLE
replaced image with os in .rtd.yml build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  image: latest
+  os: "ubuntu-22.04"
+  tools:
+    python: "3"
 
 conda:
   environment: requirements/rtd.yml
-
-formats: []


### PR DESCRIPTION
## 🚀 Pull Request

https://blog.readthedocs.com/use-build-os-config/

build.image has been deprecated, and was causing rtd build failures. This is fixed hopefully. 
I also compared the whole file with the one found in Iris, and seems generally up to date (and with less redundancy 👀).


